### PR TITLE
Updated permissions for Ansible Middleware team

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -95,13 +95,14 @@ orgs:
         description: Deploying Red Hat Middleware using Ansible
         maintainers:
           - sabre1041
-        members:
           - rpelisse
+        members:
           - davgordo
           - jlozadad
         privacy: closed
         repos:
           ansible-role-jboss-common: write
+          automate-jcliff: write
           jboss_amq: write
           jboss_amq_openshift: write
           jboss_bxms: write


### PR DESCRIPTION
Added maintainers and `automate-jcliff` repository to Ansible Middleware team