### PR TITLE
Add Prow CI bot to ditl mergers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -68,6 +68,7 @@ orgs:
       - pavelanni
       - pcarney8
       - raffaelespazzoli
+      - redhat-cop-ci-bot
       - rhjcd
       - rpelisse
       - rut31337
@@ -905,6 +906,7 @@ orgs:
                   - springdo
                   - raffaelespazzoli
                   - malacourse
+                  - redhat-cop-ci-bot
                 privacy: closed
                 repos:
                   casl-ansible: read


### PR DESCRIPTION
As we explore using Prow we'll need to add Prow's GH user with admin/write privs to the repos we intend to use it for.