### PR TITLE
Add Gareth Healy to day-in-the-life-mergers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -868,7 +868,6 @@ orgs:
               - springdo
               - raffaelespazzoli
               - malacourse
-              - garethahealy
             privacy: closed
             repos:
               casl-ansible: read
@@ -913,6 +912,7 @@ orgs:
                   - raffaelespazzoli
                   - malacourse
                   - tylerauerbeck
+                  - garethahealy
                   - redhat-cop-ci-bot
                 privacy: closed
                 repos:


### PR DESCRIPTION
Gareth has been a very active contributor in the pipeline-library repo and we can certainly use his help managing this repo.
He had also been added twice to day-in-the-life team hence the removal here.