### PR TITLE
Fix resource-locker-operator repo name

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -995,7 +995,7 @@ orgs:
               pipeline-library: read
               redhat-cop-operators: read
               rhc-ocp-playbook-test: read
-              resource-operator-locker: read
+              resource-locker-operator: read
               rocketchat-integrations: read
               spring-rest: read
               uncontained.io: read


### PR DESCRIPTION
We saw https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-org-sync-redhat-cop/309 failing with the following message after https://github.com/redhat-cop/org/pull/53 was merged.

```
msg":"Configuration failed: failed to configure redhat-cop team container-cop repos: [failed to configure redhat-cop child team operators-wg repos: [failed to update team 3299468(operators-wg) permissions on repo resource-operator-locker to read: status code 404 not one of [204], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://developer.github.com/v3/teams/#add-or-update-team-repository\"}]]"}
```

Looks like the name of the https://github.com/redhat-cop/resource-locker-operator repo was put in the config wrong.

/cc @sabre1041 @oybed 
