### PR TITLE
mdt-quickstart was renamed to pelorus

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1154,7 +1154,7 @@ orgs:
           - prakritiverma
         privacy: closed
         repos:
-          mdt-quickstart: write
+          pelorus: write
       ninja-program:
         description: ""
         maintainers:


### PR DESCRIPTION
I have no idea what these repos are, but `pelorus` is where https://github.com/redhat-cop/mdt-quickstart currenly redirects me.

Should fix https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-org-sync-redhat-cop/365#1:build-log.txt%3A269

xref: https://github.com/openshift/release/issues/6156