### PR TITLE
Add entry for the resource dispatcher to the group vars

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -374,7 +374,7 @@ orgs:
           - name: jacobsee
             type: user
             role: admin
-          - name: resource_dispatcher
+          - name: pushbot
             type: robot
             role: write
       - name: resource-locker-operator

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -368,6 +368,15 @@ orgs:
           - name: containers_quickstarts
             type: robot
             role: write
+      - name: resource-dispatcher
+        visibility: public
+        permissions:
+          - name: jacobsee
+            type: user
+            role: admin
+          - name: resource_dispatcher
+            type: robot
+            role: write
       - name: resource-locker-operator
         visibility: public
         permissions:


### PR DESCRIPTION
Adds permission definitions for the resource-dispatcher Quay repo. To go alongside https://github.com/redhat-cop/org/issues/239