### PR TITLE
automate_tower_lab was renamed to tower_configuration_examples

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -261,7 +261,6 @@ orgs:
           automate-jcliff: write
           automate-tower: write
           automate-tower-ha-dr: write
-          automate_tower_lab: write
           automate-windows: write
           cloud_provision_automation_collection: write
           hardware_automation_collection: write
@@ -269,6 +268,7 @@ orgs:
           redhat_sso: write
           jboss_webserver: write
           tower_configuration: write
+          tower_configuration_examples: write
         teams:
           automation-cop-mgrs:
             description: ""


### PR DESCRIPTION
The `org-update-config` [job](https://prow-default.apps.ci-1.cop.rht-labs.com/?job=org-update-configs) is failing
```
{
  "component":"peribolos",
  "file":"prow/cmd/peribolos/main.go:201",
  "func":"main.main",
  "level":"fatal",
  "msg":"Configuration failed: failed to configure redhat-cop team automation-cop-members repos: failed to update team 3040689(automation-cop-members) permissions on repo automate_tower_lab to write: status code 404 not one of [204], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://developer.github.com/v3/teams/#add-or-update-team-repository\"}",
  "severity":"fatal",
  "time":"2020-08-02T19:54:28Z"
}
```
Looks like the repo has been renamed
```
curl -v https://github.com/redhat-cop/automate_tower_lab 2>&1|grep location
* successfully set certificate verify locations:
< location: https://github.com/redhat-cop/tower_configuration_examples
```