### PR TITLE
Adding an infra-ansible quay.io repo

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -194,6 +194,18 @@ orgs:
           - name: pushbot
             type: robot
             role: write
+      - name: infra-ansible
+        visibility: public
+        permissions:
+          - name: pushbot
+            type: robot
+            role: write
+          - name: casl
+            type: team
+            role: admin
+          - name: obedin
+            type: user
+            role: admin
       - name: jenkins-agent-python
         visibility: public
         permissions:


### PR DESCRIPTION
New infra-ansible quay.io repo to host an infra-ansible container image. 

Related infra-ansible PR: https://github.com/redhat-cop/infra-ansible/pull/543
