### PR TITLE
Fix project initialize operator team permissions

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1088,7 +1088,7 @@ orgs:
           - otatman
         privacy: closed
         repos:
-          project-initialize-operator: admin
+          project-initialize-operator: write
         teams:
           project-initializer-mergers:
             description: ""
@@ -1099,7 +1099,7 @@ orgs:
               - gnekic
             privacy: closed
             repos:
-              project-initialize-operator: write
+              project-initialize-operator: admin
       pubcop:
         description: ""
         maintainers:


### PR DESCRIPTION
Peribolos is erroring on the `org-update-configs-sync` job
```
{"component":"peribolos","file":"prow/cmd/peribolos/main.go:201","func":"main.main","level":"fatal","msg":"Configuration failed: failed to configure redhat-cop team project-initializer repos: failed to configure redhat-cop child team project-initializer-mergers repos: failed to update team 3659163(project-initializer-mergers) permissions on repo project-initialize-operator to write: status code 422 not one of [204], body: {\"message\":\"Validation Failed\",\"documentation_url\":\"https://docs.github.com/rest/reference/teams#add-or-update-team-repository-permissions\"}","severity":"fatal","time":"2020-09-17T19:01:55Z"}
{"component":"entrypoint","error":"wrapped process failed: exit status 1","file":"prow/entrypoint/run.go:79","func":"k8s.io/test-infra/prow/entrypoint.Options.Run","level":"error","msg":"Error executing test process","time":"2020-09-17T19:01:55Z"}
```

The `project-initializer-mergers` team can't have write permissions on `project-initialize-operator` because it is inheriting `admin` as a sub team of `project-initializer`. This PR is changing team `project-initializer` to `write` and `project-initializer-mergers` to `admin`.