### PR TITLE
Add dynamic-rbac-operator to inventory

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -116,6 +116,15 @@ orgs:
           - name: ablock
             type: user
             role: admin
+      - name: dynamic-rbac-operator
+        visibility: public
+        permissions:
+          - name: jacobsee
+            type: user
+            role: admin
+          - name: pushbot
+            type: robot
+            role: write
       - name: egressip-ipam-operator
         visibility: public
         permissions:


### PR DESCRIPTION
Would like a new Quay repo for `dynamic-rbac-operator` stuff, when that GitHub repo gets created (#274)