### PR TITLE
Remove Koma-Andrea

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -98,7 +98,6 @@ orgs:
       - kkoller
       - kleesc
       - kmacedovarela
-      - Koma-Andrea
       - leethomasrh
       - leoaaraujo
       - limershein


### PR DESCRIPTION
This user no longer exist

>(*client).log","level":"info","msg":"UpdateOrgMembership(redhat-cop, koma-andrea, false)","time":"2021-02-26T03:46:38Z"}
{"component":"peribolos","error":"status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/orgs#set-organization-membership-for-a-user\"}","file":"prow/cmd/peribolos/main.go:517","func":"main.configureOrgMembers.func1","level":"warning","msg":"UpdateOrgMembership(redhat-cop, koma-andrea, false) failed","time":"2021-02-26T03:46:44Z"}

And also
```
curl -sI https://github.com/Koma-Andrea -o /dev/null -w "%{http_code}"
404
```