### PR TITLE
Move admin role to merger teams

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -804,7 +804,7 @@ orgs:
               - tylerauerbeck
             privacy: closed
             repos:
-              github-actions: admin
+              github-actions: read
             teams:
               github-actions-mergers:
                 description: GitHub Actions Mergers
@@ -814,7 +814,7 @@ orgs:
                   - tylerauerbeck
                 privacy: closed
                 repos:
-                  github-actions: write
+                  github-actions: admin
           operators-wg:
             description: ""
             maintainers:
@@ -924,7 +924,7 @@ orgs:
               - tylerauerbeck
             privacy: closed
             repos:
-              rego-policies: admin
+              rego-policies: read
             teams:
               rego-policies-mergers:
                 description: Rego policies Mergers
@@ -939,7 +939,7 @@ orgs:
                   - tylerauerbeck
                 privacy: closed
                 repos:
-                  rego-policies: write
+                  rego-policies: admin
       cyberinfrasig:
         description: "Cyber Infrastructure Special Interest Group"
         maintainers:


### PR DESCRIPTION
This should fix the following peribolos error(s)
>{"component":"peribolos","file":"prow/cmd/peribolos/main.go:201","func":"main.main","level":"fatal","msg":"Configuration failed: failed to configure redhat-cop team container-cop repos: [failed to configure redhat-cop child team github-actions repos: [failed to configure redhat-cop child team github-actions-mergers repos: [failed to update team 3710564(github-actions-mergers) permissions on repo github-actions to write: status code 422 not one of [204], body: {\"message\":\"Validation Failed\",\"documentation_url\":\"https://docs.github.com/rest/reference/teams#add-or-update-team-repository-permissions\"}]], failed to configure redhat-cop child team rego-policies repos: [failed to configure redhat-cop child team rego-policies-mergers repos: [failed to update team 3827554(rego-policies-mergers) permissions on repo rego-policies to write: status code 422 not one of [204], body: {\"message\":\"Validation Failed\",\"documentation_url\":\"https://docs.github.com/rest/reference/teams#add-or-update-team-repository-permissions\"}]], failed to configure redhat-cop child team operators-wg repos: [failed to update team 3299468(operators-wg) permissions on repo proactive-node-scaling-operator to read: status code 422 not one of [204], body: {\"message\":\"Validation Failed\",\"documentation_url\":\"https://docs.github.com/rest/reference/teams#add-or-update-team-repository-permissions\"}]]","time":"2021-02-26T09:18:49Z"}