### PR TITLE
Add initial repo definitions for new prometheus exporters & team for them

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -245,15 +245,6 @@ orgs:
           - name: pushbot
             type: robot
             role: write
-      - name: hpilo-exporter
-        visibility: public
-        permissions:
-          - name: pushbot
-            type: robot
-            role: write
-          - name: prometheusexporters
-            type: team
-            role: admin
       - name: image-scanning-signing-service
         visibility: public
         permissions:
@@ -344,15 +335,6 @@ orgs:
           - name: pushbot
             type: robot
             role: write
-      - name: lenovo-flex-exporter
-        visibility: public
-        permissions:
-          - name: pushbot
-            type: robot
-            role: write
-          - name: prometheusexporters
-            type: team
-            role: admin
       - name: microsegmentation-operator
         visibility: public
         permissions:
@@ -362,6 +344,33 @@ orgs:
           - name: pushbot
             type: robot
             role: write
+      - name: monitoring-hpilo-exporter
+        visibility: public
+        permissions:
+          - name: pushbot
+            type: robot
+            role: write
+          - name: monitoring
+            type: team
+            role: admin
+      - name: monitoring-lenovo-flex-exporter
+        visibility: public
+        permissions:
+          - name: pushbot
+            type: robot
+            role: write
+          - name: monitoring
+            type: team
+            role: admin
+      - name: monitoring-netapp-exporter
+        visibility: public
+        permissions:
+          - name: pushbot
+            type: robot
+            role: write
+          - name: monitoring
+            type: team
+            role: admin
       - name: must-gather-operator
         visibility: public
         permissions:
@@ -398,15 +407,6 @@ orgs:
           - name: pushbot
             type: robot
             role: write
-      - name: netapp-exporter
-        visibility: public
-        permissions:
-          - name: pushbot
-            type: robot
-            role: write
-          - name: prometheusexporters
-            type: team
-            role: admin
       - name: ninja-board
         visibility: public
         permissions:
@@ -720,7 +720,8 @@ orgs:
         role: creator
         members:
           - name: pabrahamsson
-      - name: prometheusexporters
+      - name: monitoring
         role: member
         members:
           - name: jacobsee
+          - name: obedin

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -245,6 +245,15 @@ orgs:
           - name: pushbot
             type: robot
             role: write
+      - name: hpilo-exporter
+        visibility: public
+        permissions:
+          - name: pushbot
+            type: robot
+            role: write
+          - name: prometheusexporters
+            type: team
+            role: admin
       - name: image-scanning-signing-service
         visibility: public
         permissions:
@@ -335,6 +344,15 @@ orgs:
           - name: pushbot
             type: robot
             role: write
+      - name: lenovo-flex-exporter
+        visibility: public
+        permissions:
+          - name: pushbot
+            type: robot
+            role: write
+          - name: prometheusexporters
+            type: team
+            role: admin
       - name: microsegmentation-operator
         visibility: public
         permissions:
@@ -380,6 +398,15 @@ orgs:
           - name: pushbot
             type: robot
             role: write
+      - name: netapp-exporter
+        visibility: public
+        permissions:
+          - name: pushbot
+            type: robot
+            role: write
+          - name: prometheusexporters
+            type: team
+            role: admin
       - name: ninja-board
         visibility: public
         permissions:
@@ -693,3 +720,7 @@ orgs:
         role: creator
         members:
           - name: pabrahamsson
+      - name: prometheusexporters
+        role: member
+        members:
+          - name: jacobsee


### PR DESCRIPTION
Repos for some of our infra monitoring prometheus exporters.

Questions:
1. Should `pushbot` be on these at all if we're going to use Quay's built-in image builder?
2. Should the team name be `prometheusexporters` or something like `prometheusexportermaintainers`? Seemed to be getting a bit long...

cc: @oybed 