### PR TITLE
Pin ansible-lint to 5.4.0 to fix issue with ansible-lint action

### DIFF
--- a/.github/workflows/quay-mgmt.yml
+++ b/.github/workflows/quay-mgmt.yml
@@ -18,6 +18,8 @@ jobs:
         uses: ansible/ansible-lint-action@master
         with:
           targets: "."
+          override-deps: |
+            ansible-lint==5.4.0
       - name: Install Dependencies
         run: ansible-galaxy install -r ansible/requirements.yml
       - name: Manage Quay Repository


### PR DESCRIPTION
The Quay Mgmt action is failing
```
+ ansible-lint -v --force-color .
Traceback (most recent call last):
  File "/usr/local/bin/ansible-lint", line 5, in <module>
    from ansiblelint.__main__ import main
  File "/usr/local/lib/python3.8/site-packages/ansiblelint/__main__.py", line 37, in <module>
    from ansiblelint.generate_docs import rules_as_rich, rules_as_rst
  File "/usr/local/lib/python3.8/site-packages/ansiblelint/generate_docs.py", line 6, in <module>
    from rich.console import render_group
ImportError: cannot import name 'render_group' from 'rich.console' (/usr/local/lib/python3.8/site-packages/rich/console.py)
```
Newer versions of ansible-lint seems to be working.
```
❯ ansible-lint --version
ansible-lint 5.4.0 using ansible 2.12.3
❯ ansible-lint -v --force-color .
INFO     Discovered files to lint using: git ls-files --cached --others --exclude-standard -z
INFO     Excluded removed files using: git ls-files --deleted -z
```