### PR TITLE
FIX: Update Peribolos config with renamed Tower repositories

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -352,9 +352,9 @@ orgs:
           redhat_sso: write
           jboss_webserver: write
           ee_utilities: write
-          tower_configuration: write
+          controller_configuration: write
           tower_configuration_examples: write
-          tower_utilities: write
+          aap_utilities: write
         teams:
           automation-cop-mgrs:
             description: ""
@@ -380,9 +380,9 @@ orgs:
               hardware_automation_collection: admin
               molecule_cicd_automation: admin
               ee_utilities: admin
-              tower_configuration: admin
+              controller_configuration: admin
               tower_configuration_examples: admin
-              tower_utilities: admin
+              aap_utilities: admin
       automation-cop-tower-mgrs:
         description: Tower managers of Automation CoP
         maintainers:
@@ -391,9 +391,9 @@ orgs:
         repos:
           ah_configuration: admin
           ee_utilities: admin
-          tower_configuration: admin
+          controller_configuration: admin
           tower_configuration_examples: admin
-          tower_utilities: admin
+          aap_utilities: admin
         privacy: closed
       businessautomation-cop:
         description: Contributors to the Business Automation CoP


### PR DESCRIPTION
It appears that a few repositories have been renamed which is causing Peribolos to fail.
- tower_configuration -> [controller_configuration](/redhat-cop/tower_configuration)
- tower_utilities -> [aap_utilities](/redhat-cop/tower_utilities)
```
{"component":"peribolos","file":"k8s.io/test-infra/prow/cmd/peribolos/main.go:209","func":"main.main","level":"fatal","msg":"Configuration failed: failed to configure redhat-cop team automation-cop-members repos: [failed to update team 3040689(automation-cop-members) permissions on repo tower_configuration to write: status code 404 not one of [204], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/teams#add-or-update-team-repository-permissions\"},
failed to update team 3040689(automation-cop-members) permissions on repo tower_utilities to write: status code 404 not one of [204], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/teams#add-or-update-team-repository-permissions\"},
failed to configure redhat-cop child team automation-cop-mgrs repos: [failed to update team 3040678(automation-cop-mgrs) permissions on repo tower_configuration to admin: status code 404 not one of [204], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/teams#add-or-update-team-repository-permissions\"},
failed to update team 3040678(automation-cop-mgrs) permissions on repo tower_utilities to admin: status code 404 not one of [204], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/teams#add-or-update-team-repository-permissions\"}]]","severity":"fatal","time":"2022-03-23T11:50:14Z"}
```