### PR TITLE
Remove vvaldez from Automation CoP members, leave as maintainer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -339,7 +339,6 @@ orgs:
           - sean-m-sullivan
           - Tompage1994
           - victorock
-          - vvaldez
         privacy: closed
         repos:
           automate-cicd: write


### PR DESCRIPTION
@mophahr I had missed that vvaldez was already a member of `automation-cop-members`, he can't be both in `maintainers` and `members`. This should fix the issue, please approve if this looks good?