### PR TITLE
Add jillr and cidrblock as admin

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,8 @@ orgs:
       - oybed
       - pabrahamsson
       - sabre1041
+      - cidrblock # Ansible engineering
+      - jillr # Ansible engineering
     billing_email: esauer@redhat.com
     company: ""
     default_repository_permission: read


### PR DESCRIPTION
Over the next few months as part of the Ansible Validated Content program repositories will need to be migrated from other organizations to this organization.

To facilitate this process, Jill and I are requesting admin access during this time. After the migrations and initial set-ups are complete the permission as code PR process should be fine moving forward and we will ask to have ourselves removed.

Configuration of any migrated repositories will be done with the config-as-code PR process and approved by Jill or I.

Please let me know if there are questions or more context is needed, Happy to talk.
