### PR TITLE
🌿add openshift-mgm repo to admin access🌿

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -778,6 +778,7 @@ orgs:
                   pipeline-library: admin
                   spring-rest: write
                   template2helm: admin
+                  openshift-management: admin
           declarative-openshift:
             description: Maintainers of the declarative-openshift repo
             maintainers:


### PR DESCRIPTION
We need to publish helm charts in openshift-management repository in order to use it as a dependency for other helm charts. For example, using [cronjob ldap sync helm chart](https://github.com/redhat-cop/openshift-management/tree/master/charts/cronjob-ldap-group-sync) as a dependency to [FreeIPA helm chart].(https://github.com/redhat-cop/helm-charts/tree/master/charts/ipa)
In order to set up GitHub Actions to release the charts and GitHub Pages to publish them, we need to have admin access to the repository.