### PR TITLE
Add firewall_mgmt to validated content/tower team

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -460,6 +460,7 @@ orgs:
           network.base: admin
           network.bgp: admin
           network.vpn: admin
+          security.firewall_mgmt: admin
           services_catalog_configuration: admin
       blockchain-cop:
         description: The Blockchain Community of Practice


### PR DESCRIPTION
This gives the tower mgmt (ansible) team admin access to the security.firewall_mgmt repo which is validated content.