### PR TITLE
fix: add missing members to CoP

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -96,6 +96,7 @@ orgs:
       - gsampaio-rh
       - hfenner
       - huddlesj
+      - hultzj
       - hwurht
       - ianwatsonrh
       - ibazulic
@@ -226,6 +227,7 @@ orgs:
       - stratus-ss
       - sushilsuresh
       - sysmatrix1
+      - swarren
       - tech2734
       - theckang
       - themoosman


### PR DESCRIPTION
Automation is failing due to missing members introduced in #519
> {"component":"peribolos","file":"k8s.io/test-infra/prow/cmd/peribolos/main.go:209","func":"main.main","level":"fatal","msg":"Configuration failed: failed to configure redhat-cop members: all team members/maintainers must also be org members: hultzj, swarren","severity":"fatal","time":"2022-11-10T11:36:58Z"}
