### PR TITLE
fix: Typo for resolutecoder username

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -205,7 +205,7 @@ orgs:
       - ramius345
       - ravisantoshgudimetla
       - rdruss
-      - esolutecoder
+      - resolutecoder
       - rflorenc
       - rhjcd
       - richardwalkerdev
@@ -456,7 +456,7 @@ orgs:
           - alinabuzachis
           - ashwini-mhatre
           - cidrblock
-          - esolutecoder
+          - resolutecoder
           - gomathiselvis
           - goneri
           - gravesm


### PR DESCRIPTION
The [CI has been failing](https://github.com/redhat-cop/org/actions/runs/3843357556/jobs/6545537003) for a while due to an incorrect username, `esolutecoder`.
This username is not in use:
```
❯ curl https://github.com/esolutecoder -so /dev/null -w %{http_code}                                     
404
❯ curl https://github.com/resolutecoder -so /dev/null -w %{http_code}                                    
200
```
This PR should fix this