### PR TITLE
Rename cloud.azure_roles repo to cloud.azure_ops

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -480,7 +480,7 @@ orgs:
           ansible_collections_tooling: admin
           cloud.aws_ops: admin
           cloud.aws_troubleshooting: admin
-          cloud.azure_roles: admin
+          cloud.azure_ops: admin
           controller_configuration: admin
           ee_utilities: admin
           infra.osbuild: admin


### PR DESCRIPTION
We've renamed this repo to comply with naming conventions for the Validated Content program