### PR TITLE
Add new cloud.terraform_ops repo to validated content

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -557,6 +557,7 @@ orgs:
               cloud.aws_troubleshooting: admin
               cloud.azure_ops: admin
               cloud.gcp_ops: admin
+              cloud.terraform_ops: admin
               edge.microshift: admin
               ee_utilities: write
               infra.leapp: admin
@@ -1461,7 +1462,7 @@ orgs:
         repos:
           rhel-edge-automation-arch: admin
       rhis-builder:
-        description: A Red Hat Technology based lab environment suitable for demonstrating a Red Hat opinionated architecture involving automated Standard Operating Environments for Red Hat Enterprise Linux. 
+        description: A Red Hat Technology based lab environment suitable for demonstrating a Red Hat opinionated architecture involving automated Standard Operating Environments for Red Hat Enterprise Linux.
         maintainers: []
         members: []
         privacy: closed
@@ -1483,7 +1484,7 @@ orgs:
               - mhjacks
             members: []
             privacy: closed
-            repos: 
+            repos:
               rhis-builder: write
       serverlessworkflow-decisioning-cop:
         description: Contributors to the ServerlessWorkFlow & Decisioning CoP


### PR DESCRIPTION
Repo needs to be created first, see https://github.com/redhat-cop/org/issues/639.