### PR TITLE
removed quay teams as no longer needed

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1400,27 +1400,6 @@ orgs:
             privacy: closed
             repos:
               public-cloud-cop: write
-      quay:
-        description: ""
-        maintainers:
-          - sabre1041
-        members:
-          - alecmerdler
-          - ibazulic
-          - kleesc
-          - thomasmckay
-        privacy: closed
-        repos: {}
-      quay-mgrs:
-        description: ""
-        maintainers:
-          - sabre1041
-        members:
-          - alecmerdler
-          - kleesc
-          - thomasmckay
-        privacy: closed
-        repos: {}
       redhat-cop-sre:
         description: "Red Hat CoP SRE"
         maintainers:


### PR DESCRIPTION
quay operator was migrated to the quay github org a while ago. so don't see why these teams are needed anymore