### PR TITLE
removed uncontained.io from config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1533,28 +1533,3 @@ orgs:
         privacy: closed
         repos:
           testing-cop: admin
-      uncontained.io:
-        description: Uncontained.io
-        maintainers:
-          - etsauer
-          - sabre1041
-        members:
-          - ahardin-rh
-          - jaredburck
-        privacy: closed
-        repos:
-          openshift-playbooks: read
-          uncontained.io: read
-        teams:
-          content-coalition:
-            description: Content Decision Makers for Uncontained.io
-            maintainers:
-              - etsauer
-              - sabre1041
-            members:
-              - ahardin-rh
-              - jaredburck
-            privacy: closed
-            repos:
-              openshift-playbooks: read
-              uncontained.io: read


### PR DESCRIPTION
same as others, uncontained.io is archived so the team is redundant  