### PR TITLE
added mhjacks

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -171,6 +171,7 @@ orgs:
       - maxamillion
       - mbogoevici
       - mffiedler
+      - mhjacks
       - mijaros
       - mike4263
       - mm7259


### PR DESCRIPTION
@mhjacks is part of a sub team but not the top level org. he keeps getting sent invitations but cant accept them for some reason. wondering if its because of this.