### PR TITLE
removed non-rh

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -125,7 +125,6 @@ orgs:
       - jfilipcz
       - jflowers
       - jhawkinsrh
-      - jijiechen
       - jillr
       - jimdillon
       - jkupferer
@@ -198,7 +197,6 @@ orgs:
       - pamenon
       - parmstro
       - pathfinder-waffle
-      - paulbarfuss
       - pauljamesbrown
       - pecorawal
       - perryrivera1
@@ -773,7 +771,6 @@ orgs:
                   - sabre1041
                 members:
                   - pabrahamsson
-                  - paulbarfuss
                 privacy: closed
                 repos:
                   applier-cli: write
@@ -843,7 +840,6 @@ orgs:
               - garethahealy
               - gsampaio-rh
               - infosec812
-              - jijiechen
               - jtudelag
               - malacourse
               - mvmaestri


### PR DESCRIPTION
@jijiechen @paulbarfuss are showing as not having accepted the github invites but did a few years ago. but looking at their GH profile, they no longer work for RH which would suggest they've manually left the org.