### PR TITLE
removed gsampaio-rh from teams with extra perms

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -845,7 +845,6 @@ orgs:
               - ckavili
               - eformat
               - garethahealy
-              - gsampaio-rh
               - infosec812
               - jtudelag
               - malacourse
@@ -887,7 +886,6 @@ orgs:
                   - ckavili
                   - eformat
                   - garethahealy
-                  - gsampaio-rh
                   - infosec812
                   - jtudelag
                   - malacourse


### PR DESCRIPTION
spoke to @gsampaio-rh offline. they've switched roles so they no longer need higher perms than general to the org.