### PR TITLE
added missing members

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,6 +32,7 @@ orgs:
       - aizuddin85
       - aleixhub
       - alinabuzachis
+      - andywaltlova
       - arnaik-rh
       - arthomasredhat
       - arvin-a
@@ -159,6 +160,7 @@ orgs:
       - mandar242
       - marcosmamorim
       - matallen
+      - matejbuocik
       - mathianasj
       - matoval
       - mattheh
@@ -168,6 +170,7 @@ orgs:
       - mhjacks
       - mijaros
       - mike4263
+      - monnte
       - mophahr
       - mpetrive-rh
       - mumeno
@@ -229,6 +232,7 @@ orgs:
       - shah-zobair
       - silvinux
       - smrowley
+      - solumath
       - springdo
       - stencell
       - stephennimmo


### PR DESCRIPTION
CI is broken due to:

```
Configuration failed: failed to configure redhat-cop members: all team members/maintainers must also be org members: andywaltlova, matejbuocik, monnte, solumath
```

PR fixes.