### PR TITLE
updated quay tool-box config

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -797,7 +797,7 @@ orgs:
           - name: etsauer
             type: user
             role: admin
-          - name: contributors
+          - name: containers_quickstarts
             type: team
             role: write
       - name: ubi7-gitlab-runner


### PR DESCRIPTION
tool-box push to quay is failing. 
- https://github.com/redhat-cop/containers-quickstarts/actions/runs/8466650743/job/23195850734

I think this should fix it. @springdo needs for a customer

@pabrahamsson ; will this fix the issue?