### PR TITLE
Updating new members for Agnosticd-core membership from RHDP team

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -316,16 +316,16 @@ orgs:
       agnosticd-core:
         description: Core team members for the agnosticd project.
         maintainers:
+          - 9strands
           - agonzalezrh
+          - d-jana
           - fridim
           - jkupferer
           - prakhar1985
+          - rut31337
           - tonykay
           - wkulhanek
-          - rut31337
           - yvarbanov
-          - d-jana
-          - 9strands
         members: []
         privacy: closed
         repos:

--- a/config.yaml
+++ b/config.yaml
@@ -322,6 +322,10 @@ orgs:
           - prakhar1985
           - tonykay
           - wkulhanek
+          - rut31337
+          - yvarbanov
+          - d-jana
+          - 9strands
         members: []
         privacy: closed
         repos:


### PR DESCRIPTION
Adding members of the RHDP team to agnosticd-core team to increase coverage.