### PR TITLE
Update access list for Ansible-eng managed collections

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -564,7 +564,6 @@ orgs:
               - bardielle
               - cidrblock
               - gomathiselvis
-              - goneri
               - gravesm
               - guidograzioli
               - hakbailey
@@ -576,7 +575,9 @@ orgs:
               - mandar242
               - matoval
               - maxamillion
+              - nirarg
               - nilashishc
+              - p3ck
               - qalthos
               - ranabirchakraborty
               - resolutecoder


### PR DESCRIPTION
Remove goneri who has moved to another role in Ansible outside of collections
Add 2 new content engineers who will be working on cloud.azure_ops