### PR TITLE
removed ashwini-mhatre as no longer in ldap

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -232,7 +232,6 @@ orgs:
       - stephennimmo
       - stocky37
       - strangiato
-      - sushilsuresh
       - swapdisk
       - sysmatrix1
       - tech2734

--- a/config.yaml
+++ b/config.yaml
@@ -36,7 +36,6 @@ orgs:
       - arthomasredhat
       - arvin-a
       - ashokjammula1
-      - ashwini-mhatre
       - bardielle
       - bbeaudoin
       - bbethell-1
@@ -338,7 +337,6 @@ orgs:
       ansible-networking:
         description: Ansible Networking
         maintainers:
-          - ashwini-mhatre
           - cidrblock
           - kb-perbyte
           - nilashishc
@@ -576,7 +574,6 @@ orgs:
               - abikouo
               - aliakkaya7
               - alinabuzachis
-              - ashwini-mhatre
               - bardielle
               - cidrblock
               - gomathiselvis


### PR DESCRIPTION
@ashwini-mhatre (amhatre@redhat.com) no longer in LDAP