### PR TITLE
added repos into the appdev team

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -435,6 +435,9 @@ orgs:
               - jeremyrdavis
               - pamenon
             privacy: closed
+            repo:
+              appdev-cop: admin
+              quarkus-scalable-graphql-demo: admin
       auto-docs:
         description: ""
         maintainers:


### PR DESCRIPTION
the `maintainers` listed here
- https://github.com/redhat-cop/org/blob/main/config.yaml#L412-L428

all have `read` access, but i'd expect them to be `admins`. i think its because the `committers` team doesn't have any repos mentioned. have added it to see if that'll fix.

@oybed @pabrahamsson @sabre1041 ; think that's the problem?