### PR TITLE
fixed typo that is causing permissions not to be granted correctly

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -422,7 +422,7 @@ orgs:
           - sangeetaraghu
           - smrowley
         privacy: closed
-        repo:
+        repos:
           appdev-cop: admin
           quarkus-scalable-graphql-demo: admin
         teams:
@@ -434,7 +434,7 @@ orgs:
               - jeremyrdavis
               - pamenon
             privacy: closed
-            repo:
+            repos:
               appdev-cop: admin
               quarkus-scalable-graphql-demo: admin
       auto-docs:


### PR DESCRIPTION
`repo` vs `repos` - actually, i dont think it was anything to do with the teams, it was because of this typo...
- https://github.com/redhat-cop/org/issues/813