### PR TITLE
removed monnte as no longer in ldap

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -166,7 +166,6 @@ orgs:
       - mijaros
       - mike4263
       - mmtktl
-      - monnte
       - mophahr
       - mpetrive-rh
       - mwitzenm
@@ -1392,7 +1391,6 @@ orgs:
         members:
           - djdanielsson
           - matejbuocik
-          - monnte
           - solumath
         privacy: closed
         repos:


### PR DESCRIPTION
@Monnte (pzdravec@redhat.com) is no longer showing up in LDAP, so I presume they have left RH