### PR TITLE
removed jbride as no longer at rh

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -106,7 +106,6 @@ orgs:
       - ivarmu
       - jarcher
       - jayfray12
-      - jbride
       - jeckersb
       - jeffcpullen
       - jeffmcutter


### PR DESCRIPTION
@jbride (jbride@redhat.com) is no longer showing up in LDAP and his LinkedIn (https://www.linkedin.com/in/jeffrey-bride-796594) says he left last year