### PR TITLE
removed matejbuocik as left rh

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -154,7 +154,6 @@ orgs:
       - mannyci
       - marcosmamorim
       - matallen
-      - matejbuocik
       - mathianasj
       - matoval
       - mattheh
@@ -1389,7 +1388,6 @@ orgs:
           - r0x0d
         members:
           - djdanielsson
-          - matejbuocik
           - solumath
         privacy: closed
         repos:


### PR DESCRIPTION
@matejbuocik never accepted the invitation and has since left RH

- https://github.com/orgs/redhat-cop/people/pending_invitations
- https://www.linkedin.com/in/matejbuocik/