### PR TITLE
removed sbailleu and sysmatrix1 as unable to verify if redhatters

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -214,7 +214,6 @@ orgs:
       - ryanzhang
       - samueltauil
       - sangeetaraghu
-      - sbailleu
       - sborenst
       - sean-m-sullivan
       - senthilredhat
@@ -229,7 +228,6 @@ orgs:
       - stocky37
       - strangiato
       - swapdisk
-      - sysmatrix1
       - tech2734
       - theckang
       - themoosman
@@ -649,7 +647,6 @@ orgs:
           - shah-zobair
           - springdo
           - stocky37
-          - sysmatrix1
           - themoosman
           - vvaldez
         privacy: closed
@@ -951,7 +948,6 @@ orgs:
               - kkoller
               - mathianasj
               - nickjordan
-              - sysmatrix1
               - trevorbox
             privacy: closed
             repos:
@@ -1257,7 +1253,6 @@ orgs:
           - mattheh
           - oybed
           - raffaelespazzoli
-          - sbailleu
           - themoosman
         privacy: closed
         repos: {}


### PR DESCRIPTION
As per https://github.com/redhat-cop/org/issues/830 - I've been unable to verify who they are from LDAP, GithHub profile or LinkedIn search.

These are the last 2 people who are unknown, everyone else in the org has their GitHub ID linked to their RH ID.