### PR TITLE
added pre-commit yq sort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .idea/
-.pre-commit-config.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: org-sort
+        name: org-sort
+        entry: ./org-sort.sh
+        language: system
+        pass_filenames: false

--- a/org-sort.sh
+++ b/org-sort.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# As two yq's exist on garethahealy machine, need to work around via
+cmd="yq_mikefarah"
+command -v yq_mikefarah &> /dev/null || { cmd="yq"; }
+
+# Check yq installed
+command -v ${cmd} &> /dev/null || { echo >&2 'ERROR: yq not installed - Aborting'; exit 1; }
+
+# Two versions of yq exist, check its the correct one
+[[ $(${cmd} --help | grep -c "github.com/mikefarah/yq") -eq 1 ]] || { echo >&2 'ERROR: found yq installed but not mikefarahs version (https://github.com/mikefarah/yq) - Aborting'; exit 1; }
+
+${cmd} -i e '(... | select(type == "!!seq"))[] |= downcase' config.yaml && \
+  # sort all lists
+  ${cmd} -i e '(... | select(type == "!!seq")) |= sort' config.yaml && \
+  # sort all keys
+  ${cmd} -i 'sort_keys(..)' config.yaml


### PR DESCRIPTION
since we suggest using `yq` to sort/lowercase the whole config.yaml and enforce it via a github action, it might be a good idea to add a pre-commit hook that does the same job.

if someone has pre-commit installed, they can enable it. if not, life continues as-is now.

the script has a minor hack/fix in it, as there are 2 different versions of `yq` - which is why the script does the weird checking for `yq_mikefarah` at the beginning.