### PR TITLE
Revert "New RHDP team member access"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -95,7 +95,6 @@ orgs:
       - gsampaio-rh
       - guidograzioli
       - hakbailey
-      - hararora123
       - hcherukuri
       - heatmiser
       - hector-vido
@@ -1191,7 +1190,6 @@ orgs:
           - bbethell-1
           - bosebc
           - d-jana
-          - hararora123
           - klewis0928
           - makirill
           - marcosmamorim
@@ -1271,7 +1269,6 @@ orgs:
               - bbethell-1
               - d-jana
               - fridim
-              - hararora123
               - jkupferer
               - newgoliath
               - wkulhanek


### PR DESCRIPTION
Reverts redhat-cop/org#928 that I accidentally merged not seeing the label saying not ready yet. 