### PR TITLE
updated peribolos images to use new google registry

### DIFF
--- a/.github/workflows/manage-github-org.yml
+++ b/.github/workflows/manage-github-org.yml
@@ -9,24 +9,24 @@ on:
         type: boolean
       GHPROXY_IMAGE:
         description: "GHProxy Image"
-        default: "gcr.io/k8s-prow/ghproxy"
+        default: "us-docker.pkg.dev/k8s-infra-prow/images/ghproxy"
         required: false
         type: string
       GHPROXY_IMAGE_VERSION:
         description: "GHProxy Image Version"
-        # renovate: datasource=docker depName=ghproxy lookupName=gcr.io/k8s-prow/ghproxy versioning=loose
-        default: "v20240805-533a2035d"
+        # renovate: datasource=docker depName=ghproxy lookupName=us-docker.pkg.dev/k8s-infra-prow/images/ghproxy versioning=loose
+        default: "v20241021-9efd512d9"
         required: false
         type: string
       PERIBOLOS_IMAGE:
         description: "Peribolos Image"
-        default: "gcr.io/k8s-prow/peribolos"
+        default: "us-docker.pkg.dev/k8s-infra-prow/images/peribolos"
         required: false
         type: string
       PERIBOLOS_IMAGE_VERSION:
         description: "Peribolos Image Version"
-        # renovate: datasource=docker depName=peribolos lookupName=gcr.io/k8s-prow/peribolos versioning=loose
-        default: "v20240805-533a2035d"
+        # renovate: datasource=docker depName=peribolos lookupName=us-docker.pkg.dev/k8s-infra-prow/images/peribolos versioning=loose
+        default: "v20241021-9efd512d9"
         required: false
         type: string
     secrets:

--- a/.github/workflows/manage-github-org.yml
+++ b/.github/workflows/manage-github-org.yml
@@ -36,6 +36,7 @@ on:
 
 env:
   PERIBOLOS_TOKEN: ${{ secrets.PERIBOLOS_TOKEN }}
+  PKG_DEV_KEY: ${{ secrets.PKG_DEV_KEY }}
   GHPROXY_IMAGE: ${{ inputs.GHPROXY_IMAGE }}
   GHPROXY_IMAGE_VERSION: ${{ inputs.GHPROXY_IMAGE_VERSION }}
   PERIBOLOS_IMAGE: ${{ inputs.PERIBOLOS_IMAGE }}
@@ -71,6 +72,8 @@ jobs:
         run: |
           echo ${{ env.PERIBOLOS_TOKEN }} > $RUNNER_TEMP/token
 
+          echo "${{ env.PKG_DEV_KEY }}" | docker login us-docker.pkg.dev --username _json_key_base64 --password-stdin
+          
           docker run --rm \
             --network=${{ env.DOCKER_NETWORK }} \
             -v $RUNNER_TEMP/token:/etc/github/token \


### PR DESCRIPTION
it seems the ghproxy/peribolos images have moved from gcr.io to pkg.dev - this updates those references.