### PR TITLE
removed charles-shaw as manually left causing ci to fail

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -56,7 +56,6 @@ orgs:
       - cgwalters
       - chadmf
       - chanoian
-      - charles-shaw
       - chofstede
       - cidrblock
       - ckavili
@@ -1496,7 +1495,6 @@ orgs:
           rhis-builder-writers:
             description: "rhis-builder repository writers"
             maintainers:
-              - charles-shaw
               - mhjacks
             members: []
             privacy: closed


### PR DESCRIPTION
CI is constantly failing because @charles-shaw is no longer a member of the CoP. I believe they have manually left and pinged via email but have not received a response.