### PR TITLE
Tentative to merge the edge related teams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea/
+# Vim temporary and backup files
+.*.swp
+*~

--- a/config.yaml
+++ b/config.yaml
@@ -1435,35 +1435,6 @@ orgs:
         privacy: closed
         repos:
           rhdirt: admin
-      rhel-bootc:
-        description: "RHEL bootc"
-        maintainers:
-          - cgwalters
-          - ckyrouac
-          - jeckersb
-          - kubealex
-          - nzwulfin
-          - sabre1041
-        privacy: closed
-        repos:
-          redhat-image-mode-actions: read
-          redhat-image-mode-demo: read
-          rhel-bootc-examples: read
-        teams:
-          rhel-bootc-mergers:
-            description: "RHEL bootc Mergers"
-            maintainers:
-              - cgwalters
-              - ckyrouac
-              - jeckersb
-              - kubealex
-              - nzwulfin
-              - sabre1041
-            privacy: closed
-            repos:
-              redhat-image-mode-actions: write
-              redhat-image-mode-demo: write
-              rhel-bootc-examples: write
       rhel-cop:
         description: "Red Hat Enterprise Linux Community of Practice"
         maintainers:
@@ -1498,22 +1469,59 @@ orgs:
             privacy: closed
             repos:
               rhel-good-practices: write
-      rhel-edge-automation-arch:
-        description: RHEL for Edge Automation Deployment Architecture
+      edge-readers:
+        description: Edge repos readers
         maintainers:
-          - jordigilh
-          - nasx
+          - cgwalters
+          - ckyrouac
+          - jeckersb
+          - kubealex
+          - nzwulfin
           - sabre1041
-        members:
-          - chadmf
-          - jarcher
-          - raedrizk
-          - samueltauil
-          - stephennimmo
-          - thomasphall
         privacy: closed
         repos:
-          rhel-edge-automation-arch: admin
+          redhat-image-mode-actions: read
+          redhat-image-mode-demo: read
+          rhel-bootc-examples: read
+          infra.image_mode: write
+        teams:
+          edge-devels:
+            description: Edge repos developers
+            maintainers:
+              - cgwalters
+              - ckyrouac
+              - jeckersb
+              - kubealex
+              - nzwulfin
+              - sabre1041
+              - ericzolf
+              - claudiol
+            privacy: closed
+            repos:
+              redhat-image-mode-actions: write
+              redhat-image-mode-demo: write
+              rhel-bootc-examples: write
+              edge.image_mode: write
+            teams:
+              edge-admins:
+                description: Edge repos administrators
+                maintainers:
+                  - jordigilh
+                  - nasx
+                  - sabre1041
+                  - ericzolf
+                  - claudiol
+                members:
+                  - chadmf
+                  - jarcher
+                  - raedrizk
+                  - samueltauil
+                  - stephennimmo
+                  - thomasphall
+                privacy: closed
+                repos:
+                  edge.image_mode: admin
+                  rhel-edge-automation-arch: admin
       rhel-migration:
         description: Team focused on RHEL migrations
         maintainers:

--- a/config.yaml
+++ b/config.yaml
@@ -1129,8 +1129,8 @@ orgs:
         privacy: closed
         repos:
           disconnectedinfra: admin
-      edge-readers:
-        description: Edge repos readers
+      edge-automation:
+        description: Edge repos automation
         maintainers:
           - cgwalters
           - ckyrouac
@@ -1139,11 +1139,7 @@ orgs:
           - nzwulfin
           - sabre1041
         privacy: closed
-        repos:
-          infra.image_mode: write
-          redhat-image-mode-actions: read
-          redhat-image-mode-demo: read
-          rhel-bootc-examples: read
+        repos: {}
         teams:
           edge-devels:
             description: Edge repos developers
@@ -1162,26 +1158,25 @@ orgs:
               redhat-image-mode-actions: write
               redhat-image-mode-demo: write
               rhel-bootc-examples: write
-            teams:
-              edge-admins:
-                description: Edge repos administrators
-                maintainers:
-                  - claudiol
-                  - ericzolf
-                  - jordigilh
-                  - nasx
-                  - sabre1041
-                members:
-                  - chadmf
-                  - jarcher
-                  - raedrizk
-                  - samueltauil
-                  - stephennimmo
-                  - thomasphall
-                privacy: closed
-                repos:
-                  edge.image_mode: admin
-                  rhel-edge-automation-arch: admin
+          edge-admins:
+            description: Edge repos administrators
+            maintainers:
+              - claudiol
+              - ericzolf
+              - jordigilh
+              - nasx
+              - sabre1041
+            members:
+              - chadmf
+              - jarcher
+              - raedrizk
+              - samueltauil
+              - stephennimmo
+              - thomasphall
+            privacy: closed
+            repos:
+              edge.image_mode: admin
+              rhel-edge-automation-arch: admin
       flightpath:
         description: FlightPath blueprint for end-to-end automated OpenShift Deployment
         maintainers:

--- a/config.yaml
+++ b/config.yaml
@@ -1129,54 +1129,6 @@ orgs:
         privacy: closed
         repos:
           disconnectedinfra: admin
-      edge-automation:
-        description: Edge repos automation
-        maintainers:
-          - cgwalters
-          - ckyrouac
-          - jeckersb
-          - kubealex
-          - nzwulfin
-          - sabre1041
-        privacy: closed
-        repos: {}
-        teams:
-          edge-devels:
-            description: Edge repos developers
-            maintainers:
-              - cgwalters
-              - ckyrouac
-              - claudiol
-              - ericzolf
-              - jeckersb
-              - kubealex
-              - nzwulfin
-              - sabre1041
-            privacy: closed
-            repos:
-              edge.image_mode: write
-              redhat-image-mode-actions: write
-              redhat-image-mode-demo: write
-              rhel-bootc-examples: write
-          edge-admins:
-            description: Edge repos administrators
-            maintainers:
-              - claudiol
-              - ericzolf
-              - jordigilh
-              - nasx
-              - sabre1041
-            members:
-              - chadmf
-              - jarcher
-              - raedrizk
-              - samueltauil
-              - stephennimmo
-              - thomasphall
-            privacy: closed
-            repos:
-              edge.image_mode: admin
-              rhel-edge-automation-arch: admin
       flightpath:
         description: FlightPath blueprint for end-to-end automated OpenShift Deployment
         maintainers:
@@ -1483,6 +1435,35 @@ orgs:
         privacy: closed
         repos:
           rhdirt: admin
+      rhel-bootc:
+        description: "RHEL bootc"
+        maintainers:
+          - cgwalters
+          - ckyrouac
+          - jeckersb
+          - kubealex
+          - nzwulfin
+          - sabre1041
+        privacy: closed
+        repos:
+          redhat-image-mode-actions: read
+          redhat-image-mode-demo: read
+          rhel-bootc-examples: read
+        teams:
+          rhel-bootc-mergers:
+            description: "RHEL bootc Mergers"
+            maintainers:
+              - cgwalters
+              - ckyrouac
+              - jeckersb
+              - kubealex
+              - nzwulfin
+              - sabre1041
+            privacy: closed
+            repos:
+              redhat-image-mode-actions: write
+              redhat-image-mode-demo: write
+              rhel-bootc-examples: write
       rhel-cop:
         description: "Red Hat Enterprise Linux Community of Practice"
         maintainers:
@@ -1517,6 +1498,22 @@ orgs:
             privacy: closed
             repos:
               rhel-good-practices: write
+      rhel-edge-automation-arch:
+        description: RHEL for Edge Automation Deployment Architecture
+        maintainers:
+          - jordigilh
+          - nasx
+          - sabre1041
+        members:
+          - chadmf
+          - jarcher
+          - raedrizk
+          - samueltauil
+          - stephennimmo
+          - thomasphall
+        privacy: closed
+        repos:
+          rhel-edge-automation-arch: admin
       rhel-migration:
         description: Team focused on RHEL migrations
         maintainers:

--- a/config.yaml
+++ b/config.yaml
@@ -1129,6 +1129,54 @@ orgs:
         privacy: closed
         repos:
           disconnectedinfra: admin
+      edge-automation:
+        description: Edge repos automation
+        maintainers:
+          - cgwalters
+          - ckyrouac
+          - jeckersb
+          - kubealex
+          - nzwulfin
+          - sabre1041
+        privacy: closed
+        repos: {}
+        teams:
+          edge-admins:
+            description: Edge repos administrators
+            maintainers:
+              - claudiol
+              - ericzolf
+              - jordigilh
+              - nasx
+              - sabre1041
+            members:
+              - chadmf
+              - jarcher
+              - raedrizk
+              - samueltauil
+              - stephennimmo
+              - thomasphall
+            privacy: closed
+            repos:
+              edge.image_mode: admin
+              rhel-edge-automation-arch: admin
+          edge-devels:
+            description: Edge repos developers
+            maintainers:
+              - cgwalters
+              - ckyrouac
+              - claudiol
+              - ericzolf
+              - jeckersb
+              - kubealex
+              - nzwulfin
+              - sabre1041
+            privacy: closed
+            repos:
+              edge.image_mode: write
+              redhat-image-mode-actions: write
+              redhat-image-mode-demo: write
+              rhel-bootc-examples: write
       flightpath:
         description: FlightPath blueprint for end-to-end automated OpenShift Deployment
         maintainers:

--- a/config.yaml
+++ b/config.yaml
@@ -1129,6 +1129,59 @@ orgs:
         privacy: closed
         repos:
           disconnectedinfra: admin
+      edge-readers:
+        description: Edge repos readers
+        maintainers:
+          - cgwalters
+          - ckyrouac
+          - jeckersb
+          - kubealex
+          - nzwulfin
+          - sabre1041
+        privacy: closed
+        repos:
+          infra.image_mode: write
+          redhat-image-mode-actions: read
+          redhat-image-mode-demo: read
+          rhel-bootc-examples: read
+        teams:
+          edge-devels:
+            description: Edge repos developers
+            maintainers:
+              - cgwalters
+              - ckyrouac
+              - claudiol
+              - ericzolf
+              - jeckersb
+              - kubealex
+              - nzwulfin
+              - sabre1041
+            privacy: closed
+            repos:
+              edge.image_mode: write
+              redhat-image-mode-actions: write
+              redhat-image-mode-demo: write
+              rhel-bootc-examples: write
+            teams:
+              edge-admins:
+                description: Edge repos administrators
+                maintainers:
+                  - claudiol
+                  - ericzolf
+                  - jordigilh
+                  - nasx
+                  - sabre1041
+                members:
+                  - chadmf
+                  - jarcher
+                  - raedrizk
+                  - samueltauil
+                  - stephennimmo
+                  - thomasphall
+                privacy: closed
+                repos:
+                  edge.image_mode: admin
+                  rhel-edge-automation-arch: admin
       flightpath:
         description: FlightPath blueprint for end-to-end automated OpenShift Deployment
         maintainers:
@@ -1469,59 +1522,6 @@ orgs:
             privacy: closed
             repos:
               rhel-good-practices: write
-      edge-readers:
-        description: Edge repos readers
-        maintainers:
-          - cgwalters
-          - ckyrouac
-          - jeckersb
-          - kubealex
-          - nzwulfin
-          - sabre1041
-        privacy: closed
-        repos:
-          redhat-image-mode-actions: read
-          redhat-image-mode-demo: read
-          rhel-bootc-examples: read
-          infra.image_mode: write
-        teams:
-          edge-devels:
-            description: Edge repos developers
-            maintainers:
-              - cgwalters
-              - ckyrouac
-              - jeckersb
-              - kubealex
-              - nzwulfin
-              - sabre1041
-              - ericzolf
-              - claudiol
-            privacy: closed
-            repos:
-              redhat-image-mode-actions: write
-              redhat-image-mode-demo: write
-              rhel-bootc-examples: write
-              edge.image_mode: write
-            teams:
-              edge-admins:
-                description: Edge repos administrators
-                maintainers:
-                  - jordigilh
-                  - nasx
-                  - sabre1041
-                  - ericzolf
-                  - claudiol
-                members:
-                  - chadmf
-                  - jarcher
-                  - raedrizk
-                  - samueltauil
-                  - stephennimmo
-                  - thomasphall
-                privacy: closed
-                repos:
-                  edge.image_mode: admin
-                  rhel-edge-automation-arch: admin
       rhel-migration:
         description: Team focused on RHEL migrations
         maintainers:


### PR DESCRIPTION
This is my tentative to address issue #1009 but I'm not sure if I'm doing the right thing and I have many questions. I did my best to keep the old structures and maintainers/members, but:

1. how does the automation react to renaming teams?
2. is it necessary to have 3 levels of teams (mimicking the previous structures), couldn't we get rid of the `read` level? Doesn't anyway anybody have read level on any repo?
3. does adding the repo edge.image_mode also triggers its creation?

@sabre1041 for your attention!