### PR TITLE
added bevans as top level member

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -45,6 +45,7 @@ orgs:
       - bbethell-1
       - beeankha
       - beelandc
+      - bevans
       - bkaraoren
       - bmarlow
       - bontreger


### PR DESCRIPTION
noticed CI complaining about @bevans - was added via https://github.com/redhat-cop/org/pull/1082 but not as a top level member