### PR TITLE
Remove 'selrahal' from group memberships

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -250,7 +250,6 @@ orgs:
       - sangeetaraghu
       - sborenst
       - sean-m-sullivan
-      - selrahal
       - senthilredhat
       - seravat
       - shah-zobair
@@ -1242,7 +1241,6 @@ orgs:
           - machacekondra
           - pkliczewski
           - rgoodson-redhat
-          - selrahal
           - swapdisk
         members: []
         privacy: closed
@@ -1256,7 +1254,6 @@ orgs:
             maintainers:
               - pkliczewski
               - rgoodson-redhat
-              - selrahal
             privacy: closed
             repos:
               openshift-iac: admin


### PR DESCRIPTION
Removed @selrahal from multiple groups in config.yaml. Cant find in rover/ldap anymore