### PR TITLE
Add 'aap-bridge' repository

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -2,6 +2,12 @@
 orgs:
   - name: redhat-cop
     repos:
+      - name: aap-bridge
+        visibility: public
+        permissions:
+          - name: bontreger
+            type: user
+            role: admin
       - name: argocd-operator
         visibility: public
         permissions:

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -2,15 +2,6 @@
 orgs:
   - name: redhat-cop
     repos:
-      - name: aap-bridge
-        visibility: public
-        permissions:
-          - name: bontreger
-            type: user
-            role: admin
-          - name: jeffmcutter
-            type: user
-            role: admin
       - name: argocd-operator
         visibility: public
         permissions:

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -8,6 +8,9 @@ orgs:
           - name: bontreger
             type: user
             role: admin
+          - name: jeffmcutter
+            type: user
+            role: admin
       - name: argocd-operator
         visibility: public
         permissions:

--- a/config.yaml
+++ b/config.yaml
@@ -378,6 +378,19 @@ orgs:
         privacy: closed
         repos:
           agnosticd: admin
+      ansible-bridge:
+        description: Members of the Ansible Bridge team
+        maintainers:
+          - bontreger
+          - jeffmcutter
+          - sabre1041
+          - arnav3000
+          - ericzolf
+          - wmckinley1
+        members: []
+        privacy: closed
+        repos:
+          ansible-bridge: admin
       ansible-devtools:
         description: Members of the Ansible Devtools team.
         maintainers:

--- a/config.yaml
+++ b/config.yaml
@@ -381,11 +381,11 @@ orgs:
       ansible-bridge:
         description: Members of the Ansible Bridge team
         maintainers:
+          - arnav3000
           - bontreger
+          - ericzolf
           - jeffmcutter
           - sabre1041
-          - arnav3000
-          - ericzolf
           - wmckinley1
         members: []
         privacy: closed

--- a/config.yaml
+++ b/config.yaml
@@ -38,6 +38,7 @@ orgs:
       - andrew-jones
       - anusshukla
       - arnaik-rh
+      - arnav3000
       - arthomasredhat
       - artificial-intelligence
       - arvin-a

--- a/config.yaml
+++ b/config.yaml
@@ -382,6 +382,7 @@ orgs:
       ansible-bridge:
         description: Members of the Ansible Bridge team
         maintainers:
+          - antonysallas
           - arnav3000
           - bontreger
           - ericzolf
@@ -391,7 +392,7 @@ orgs:
         members: []
         privacy: closed
         repos:
-          ansible-bridge: admin
+          aap-bridge: admin
       ansible-devtools:
         description: Members of the Ansible Devtools team.
         maintainers:


### PR DESCRIPTION
Added new repository 'aap-bridge' to host https://github.com/antonysallas/aap-bridge as a COP supported initiative