### PR TITLE
Add antonysallas to redhat-cop as member.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -36,6 +36,7 @@ orgs:
       - alisonlhart
       - ally-jarrett
       - andrew-jones
+      - antonysallas
       - anusshukla
       - arnaik-rh
       - arthomasredhat


### PR DESCRIPTION
As creator of aap-bridge to become redhat-cop/ansible-bridge.  Antony would like to be added to the redhat-cop so he can participate in redhat-cop/ansible-bridge.