### PR TITLE
Remove specified users from config.yaml as believe they've left

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -249,7 +249,6 @@ orgs:
       - rohitthakur2590
       - ronger4
       - roverflow
-      - rpelisse
       - ruchip16
       - rut31337
       - ryanzhang
@@ -300,7 +299,6 @@ orgs:
       - wilson-walrus
       - wkulhanek
       - wmckinley1
-      - wolfc
       - yaish25491
       - yigitpolat
       - yonosoyvictor
@@ -700,13 +698,11 @@ orgs:
               - rhodzelmans
               - rohitthakur2590
               - ronger4
-              - rpelisse
               - sabre1041
               - shahargolshani
               - thom-at-redhat
               - tompage1994
               - trishnaguha
-              - wolfc
               - yaish25491
             privacy: closed
             repos:
@@ -782,7 +778,6 @@ orgs:
           - noelo
           - pabrahamsson
           - raffaelespazzoli
-          - rpelisse
           - shah-zobair
           - springdo
           - stocky37


### PR DESCRIPTION
Removed users @rpelisse and @wolfc from various lists. I believe both were part of teams that transitioned over to IBM, but both dont show in LDAP anymore, whereas other transitioned teams still do.

Presume they've left RH.