### PR TITLE
Add cloud content team members

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -55,6 +55,7 @@ orgs:
       - bontreger
       - boogiespook
       - bosebc
+      - brahmanim
       - branic
       - brennanpaciorek
       - bszeti
@@ -245,6 +246,7 @@ orgs:
       - robertsandoval
       - robotsail
       - rohitthakur2590
+      - romi1495
       - ronger4
       - roverflow
       - ruchip16
@@ -665,6 +667,7 @@ orgs:
               - alinabuzachis
               - bardielle
               - beeankha
+              - brahmanim
               - chynasan
               - cidrblock
               - claudiol
@@ -694,6 +697,7 @@ orgs:
               - resolutecoder
               - rhodzelmans
               - rohitthakur2590
+              - romi1495
               - ronger4
               - sabre1041
               - shahargolshani


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

Added Ansible Cloud Content Team members