### PR TITLE
Remove david-igou from operators-wg-writers list in config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1156,7 +1156,6 @@ orgs:
                   - trevorbox
                 members:
                   - cnuland
-                  - david-igou
                   - kkoller
                   - mathianasj
                   - nickjordan


### PR DESCRIPTION
Requesting excess permissions/membership be removed while I'm not actively engaged with this space