### PR TITLE
Adding Open Knowledge repositories

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -31,6 +31,7 @@ orgs:
       - akasurde
       - albertoflorez
       - aleixhub
+      - alexgdmx
       - aliakkaya7
       - alinabuzachis
       - alisonlhart
@@ -220,6 +221,7 @@ orgs:
       - pittar
       - pkliczewski
       - prakhar1985
+      - psehgaft
       - qalthos
       - r0x0d
       - radudd
@@ -1497,6 +1499,52 @@ orgs:
           - themoosman
         privacy: closed
         repos: {}
+      open-knowledge-cop:
+        description: "Open Knowledge is a Community of Practice"
+        maintainers:
+          - alexgdmx
+          - linuxeroagrio
+          - psehgaft
+        members: []
+        privacy: closed
+        repos:
+          ok-ai: write
+          ok-automation: write
+          ok-cloud: write
+          ok-openshift: write
+          ok-rhel: write
+          ok-virt: write
+        teams:
+          open-knowledge-cop-admins:
+            description: Open Knowledge is a Community of Practice Admins
+            maintainers:
+              - alexgdmx
+              - linuxeroagrio
+              - psehgaft
+            members: []
+            privacy: closed
+            repos:
+              ok-ai: admin
+              ok-automation: admin
+              ok-cloud: admin
+              ok-openshift: admin
+              ok-rhel: admin
+              ok-virt: admin
+          open-knowledge-cop-mergers:
+            description: Open Knowledge is a Community of Practice Mergers
+            maintainers:
+              - alexgdmx
+              - linuxeroagrio
+              - psehgaft
+            members: []
+            privacy: closed
+            repos:
+              ok-ai: admin
+              ok-automation: admin
+              ok-cloud: admin
+              ok-openshift: admin
+              ok-rhel: admin
+              ok-virt: admin
       openshift-reference-architectures:
         description: "OpenShift Reference Architectures"
         maintainers:

--- a/config.yaml
+++ b/config.yaml
@@ -31,7 +31,7 @@ orgs:
       - akasurde
       - albertoflorez
       - aleixhub
-      - alexgdmx
+      - alexgdusarh
       - aliakkaya7
       - alinabuzachis
       - alisonlhart
@@ -1504,7 +1504,7 @@ orgs:
       open-knowledge-cop:
         description: "Open Knowledge is a Community of Practice"
         maintainers:
-          - alexgdmx
+          - alexgdusarh
           - joerh-ocp
           - linuxeroagrio
           - psehgaft
@@ -1521,7 +1521,7 @@ orgs:
           open-knowledge-cop-admins:
             description: Open Knowledge is a Community of Practice Admins
             maintainers:
-              - alexgdmx
+              - alexgdusarh
               - joerh-ocp
               - linuxeroagrio
               - psehgaft
@@ -1537,7 +1537,7 @@ orgs:
           open-knowledge-cop-mergers:
             description: Open Knowledge is a Community of Practice Mergers
             maintainers:
-              - alexgdmx
+              - alexgdusarh
               - joerh-ocp
               - linuxeroagrio
               - psehgaft

--- a/config.yaml
+++ b/config.yaml
@@ -1505,9 +1505,9 @@ orgs:
         description: "Open Knowledge is a Community of Practice"
         maintainers:
           - alexgdmx
+          - joerh-ocp
           - linuxeroagrio
           - psehgaft
-          - joerh-ocp
         members: []
         privacy: closed
         repos:
@@ -1522,9 +1522,9 @@ orgs:
             description: Open Knowledge is a Community of Practice Admins
             maintainers:
               - alexgdmx
+              - joerh-ocp
               - linuxeroagrio
               - psehgaft
-              - joerh-ocp
             members: []
             privacy: closed
             repos:
@@ -1538,9 +1538,9 @@ orgs:
             description: Open Knowledge is a Community of Practice Mergers
             maintainers:
               - alexgdmx
+              - joerh-ocp
               - linuxeroagrio
               - psehgaft
-              - joerh-ocp
             members: []
             privacy: closed
             repos:

--- a/config.yaml
+++ b/config.yaml
@@ -135,6 +135,7 @@ orgs:
       - jillr
       - jimdillon
       - jkupferer
+      - joerh-ocp
       - johnsimcall
       - jon2100
       - jooho
@@ -166,6 +167,7 @@ orgs:
       - leoaaraujo
       - levysantanna
       - limershein
+      - linuxeroagrio
       - linuxstudio
       - lpanza
       - lpsantil
@@ -1505,6 +1507,7 @@ orgs:
           - alexgdmx
           - linuxeroagrio
           - psehgaft
+          - joerh-ocp
         members: []
         privacy: closed
         repos:
@@ -1521,6 +1524,7 @@ orgs:
               - alexgdmx
               - linuxeroagrio
               - psehgaft
+              - joerh-ocp
             members: []
             privacy: closed
             repos:
@@ -1536,6 +1540,7 @@ orgs:
               - alexgdmx
               - linuxeroagrio
               - psehgaft
+              - joerh-ocp
             members: []
             privacy: closed
             repos:


### PR DESCRIPTION
Open Knowledge is a Community of Practice established to capture, connect, preserve, and sustain internal knowledge across Red Hatters around specific use cases, practical experiences, reusable patterns, and lessons learned from real engagements.

@etsauer can you review and merge if is ok