### PR TITLE
Add rhel-soe-ai-admins team and rhel-soe-ai repo to config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1711,11 +1711,11 @@ orgs:
           rhel-soe-ai-admins:
             description: ""
             maintainers:
-              - rydekull
               - kubealex
               - mglantz
               - myllynen
               - opuk
+              - rydekull
             members: []
             privacy: closed
             repos:

--- a/config.yaml
+++ b/config.yaml
@@ -1681,6 +1681,7 @@ orgs:
         privacy: closed
         repos:
           rhel-good-practices: admin
+          rhel-soe-ai: admin
         teams:
           rhel-cop-mgrs:
             description: ""
@@ -1693,6 +1694,7 @@ orgs:
             privacy: closed
             repos:
               rhel-good-practices: admin
+              rhel-soe-ai: admin
           rhel-good-practices-authors:
             description: ""
             maintainers:
@@ -1706,6 +1708,18 @@ orgs:
             privacy: closed
             repos:
               rhel-good-practices: write
+          rhel-soe-ai-admins:
+            description: ""
+            maintainers:
+              - Rydekull
+              - kubealex
+              - mglantz
+              - myllynen
+              - opuk
+            members: []
+            privacy: closed
+            repos:
+              rhel-soe-ai: admin
       rhel-edge-automation-arch:
         description: RHEL for Edge Automation Deployment Architecture
         maintainers:

--- a/config.yaml
+++ b/config.yaml
@@ -1711,7 +1711,7 @@ orgs:
           rhel-soe-ai-admins:
             description: ""
             maintainers:
-              - Rydekull
+              - rydekull
               - kubealex
               - mglantz
               - myllynen


### PR DESCRIPTION
Added new team 'rhel-soe-ai-admins'  and rhel-soe-ai repo with maintainers and permissions. It's added under the rhel-cop umbrella.

Cheers,
RHEL CoP Manager
Magnus