### PR TITLE
Add lightwell-adoption-demo team and related repos

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -36,6 +36,7 @@ orgs:
       - alisonlhart
       - andrew-jones
       - antonysallas
+      - anurag-saran
       - arnaik-rh
       - arnav3000
       - arthomasredhat
@@ -1486,6 +1487,16 @@ orgs:
         privacy: closed
         repos:
           infra.support_assist: admin
+      lightwell-adoption-demo:
+        description: Lightwell customer-adoption demos (badge, remediations PR, upgrade-delta grading). Public-docs-safe references only.
+        maintainers:
+          - anurag-saran
+        members: []
+        privacy: closed
+        repos:
+          lightwell-github-plugin-demo: admin
+          payments-service: admin
+          upgrade-delta: admin
       mdt:
         description: Metrics Driven Transformation
         maintainers:


### PR DESCRIPTION
## Summary
Per Ian Tewksbury’s ask to centralize Lightwell-related work under `github.com/redhat-cop` (and bookmark in `#*-lightwell-*` channels).

Adds:
- org member `anurag-saran`
- team `lightwell-adoption-demo` with admin on:
  - `payments-service` (from https://github.com/anurag-saran/payments-service)
  - `upgrade-delta` (from https://github.com/anurag-saran/upgrade-delta)
  - `lightwell-github-plugin-demo` (from https://github.com/anurag-saran/lightwell-github-plugin-demo)

## Purpose
Public demo of Lightwell adoption: README badge → remediations PR → upgrade-delta live grading / CAB comment.

## Compliance
Lightwell references in these repos use publicly documented / public demo materials only (no internal-only feeds or docs).

## Follow-up after merge
Please create empty repos (or accept transfers) for the three names above so Peribolos team bindings apply. Happy to transfer the existing personal repos once the org repos exist.

cc @garethahealy @etsauer — happy to add Philip Hayes / Paulo Menon as maintainers for curation once they have GitHub handles confirmed in this config.
