### PR TITLE
Add jwbernin and cojmckee for ASA

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -73,6 +73,7 @@ orgs:
       - claudiol
       - cmcornejocrespo
       - cnuland
+      - cojmckee
       - cpeters
       - cpmeadors
       - crenwick93
@@ -146,6 +147,7 @@ orgs:
       - juliaaano
       - juliovp01
       - juozasa
+      - jwbernin
       - kaileshmistry
       - kaiobrien
       - kb-perbyte
@@ -362,6 +364,15 @@ orgs:
           spring-rest: admin
           template2helm: admin
           uncontained.io: admin
+      advanced-satellite-arch:
+        description: Core maintainers for the Advanced Satellite Architecture code
+        maintainers:
+          - jwbernin
+          - cojmckee
+        members: []
+        privacy: closed
+        repos:
+          adv-sat-arch: admin
       agnosticd-core:
         description: Core team members for the agnosticd project.
         maintainers:


### PR DESCRIPTION
I am requesting membership in the COP in order to store Ansible code used to install and maintain the Advanced Satellite Architecture. This is a multi-tiered architecture that increases availability of Satellite services and relies on Ansible (preferably AAP) to maintain the multiple Satellites in sync with each other.

Initially, I (John Berninger) and cojmckee (Cory McKee) will be maintainers, with others added through regular contributor processes.